### PR TITLE
Adding Nord Web themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ If you feel like anything is missing, don't hesitate to create a [new issue](htt
 
 - [Theme by sublime9-design](https://www.deviantart.com/sublime9-design/art/Nord-Theme-for-Chrome-V2-837463227)
 
+
 ## Extensions 
 ### Firefox
 - [Nord Web themes](https://addons.mozilla.org/en-US/firefox/addon/nord-web-theme/)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ If you feel like anything is missing, don't hesitate to create a [new issue](htt
 * [Browsers](#Browsers)
   * [Firefox](#Firefox)
   * [Chrome](#Chrome)
+* [Extensions](#extensions)
+  * [Firefox](#Firefox)
 * [Editors](#Editors)
 * [OS](#OS)
   * [Windows](#Windows)
@@ -35,7 +37,9 @@ If you feel like anything is missing, don't hesitate to create a [new issue](htt
 
 - [Theme by sublime9-design](https://www.deviantart.com/sublime9-design/art/Nord-Theme-for-Chrome-V2-837463227)
 
-
+## Extensions 
+### Firefox
+- [Nord Web themes](https://addons.mozilla.org/en-US/firefox/addon/nord-web-theme/)
 
 ## Editors
 


### PR DESCRIPTION
A firefox extensions, that makes popular websites look like nord. Can be used on Browsers which support the Firefox Marketplace